### PR TITLE
make flux-install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/sealed-secrets-key.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: helm-release-crd fluxcd-ns flux-install all fluxctl-sync
+.PHONY: helm-release-crd fluxcd-ns flux-install all fluxctl-sync helm-operator-install
 
 fluxctl-sync:
 	fluxctl sync
 
-all: flux-install
+all: flux-install helm-operator-install
 
 helm-release-crd:
 	kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
@@ -15,3 +15,9 @@ flux-install: helm-release-crd fluxcd-ns
 	helm upgrade -i flux fluxcd/flux --wait \
 		--namespace fluxcd \
 		--set git.url=git@github.com:yebyen/helm-operator-get-started
+
+helm-operator-install:
+	helm upgrade -i helm-operator fluxcd/helm-operator --wait \
+		--namespace fluxcd \
+		--set git.ssh.secretName=flux-git-deploy \
+		--set helm.versions=v3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: helm-release-crd fluxcd-ns flux-install all fluxctl-sync helm-operator-install sealed-secrets-key backup-key restore-key
+.PHONY: helm-release-crd fluxcd-ns flux-install all fluxctl-sync helm-operator-install sealed-secrets-key backup-key
+.PHONY: restore-key uninstall-sealed-secrets uninstall-flux-helm-operator uninstall
 
 fluxctl-sync:
 	fluxctl sync
@@ -17,6 +18,7 @@ flux-install: helm-release-crd fluxcd-ns
 		--set git.url=git@github.com:yebyen/helm-operator-get-started
 
 sealed-secrets-key:
+	kubectl create namespace adm
 	kubectl apply -f sealed-secrets-key.yaml
 
 helm-operator-install: sealed-secrets-key
@@ -32,3 +34,13 @@ backup-key:
 restore-key:
 	kubectl replace secret -n adm sealed-secrets-key -f sealed-secrets-key.yaml
 	kubectl delete pod -n adm -l app=sealed-secrets
+
+uninstall-sealed-secrets:
+	kubectl delete --ignore-not-found=true clusterrole/secrets-unsealer ns/adm clusterrolebinding/sealed-secrets
+	kubectl delete --ignore-not-found=true crd sealedsecrets.bitnami.com
+
+uninstall-flux-helm-operator:
+	kubectl delete --ignore-not-found=true ns fluxcd
+	kubectl delete --ignore-not-found=true crd helmreleases.helm.fluxcd.io
+
+uninstall: uninstall-sealed-secrets uninstall-flux-helm-operator

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: helm-release-crd fluxcd-ns flux-install all
+
+all: flux-install
+
+helm-release-crd:
+	kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
+
+fluxcd-ns:
+	kubectl create namespace fluxcd
+
+flux-install: helm-release-crd fluxcd-ns
+	helm upgrade -i flux fluxcd/flux --wait \
+		--namespace fluxcd \
+		--set git.url=git@github.com:yebyen/helm-operator-get-started

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: helm-release-crd fluxcd-ns flux-install all
+.PHONY: helm-release-crd fluxcd-ns flux-install all fluxctl-sync
+
+fluxctl-sync:
+	fluxctl sync
 
 all: flux-install
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: helm-release-crd fluxcd-ns flux-install all fluxctl-sync helm-operator-install sealed-secrets-key backup-key
-.PHONY: restore-key uninstall-sealed-secrets uninstall-flux-helm-operator uninstall
+.PHONY: restore-key uninstall-sealed-secrets uninstall-flux-helm-operator uninstall identity
 
 fluxctl-sync:
 	fluxctl sync
@@ -44,3 +44,6 @@ uninstall-flux-helm-operator:
 	kubectl delete --ignore-not-found=true crd helmreleases.helm.fluxcd.io
 
 uninstall: uninstall-sealed-secrets uninstall-flux-helm-operator
+
+identity:
+	fluxctl identity

--- a/releases/sealed-secrets.yaml
+++ b/releases/sealed-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: adm
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: sealed-secrets
+  namespace: adm
+spec:
+  releaseName: sealed-secrets
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    name: sealed-secrets
+    version: 1.10.2


### PR DESCRIPTION
Among other things, `make flux-install` is a new Make target in this PR.

* This makefile will manage installing the Helm Operator and Flux with `make all`
* Has additional make targets for the sealed-secrets controller and a basic `sealed-secrets-key` lifecycle management
  * `make backup-key`
  * `make restore-key`
* Has `make uninstall` target which obliterates any trace of what `make all` does (including keys!)
* `make identity` which simply calls `fluxctl identity` to retrieve generated deploy keys from Flux