### PR TITLE
WIP: Upgrade workflow chart for K8s 1.16

### DIFF
--- a/workflow/charts/builder/templates/_helpers.tmpl
+++ b/workflow/charts/builder/templates/_helpers.tmpl
@@ -10,3 +10,12 @@ rbac.authorization.k8s.io/v1alpha1
 rbac.authorization.k8s.io/v1
 {{- end -}}
 {{- end -}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/builder/templates/builder-deployment.yaml
+++ b/workflow/charts/builder/templates/builder-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-builder

--- a/workflow/charts/database/templates/_helpers.tmpl
+++ b/workflow/charts/database/templates/_helpers.tmpl
@@ -1,0 +1,12 @@
+{{/*
+Set apiVersion based on .Capabilities.APIVersions
+*/}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/database/templates/database-deployment.yaml
+++ b/workflow/charts/database/templates/database-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.database_location "on-cluster" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-database

--- a/workflow/charts/fluentd/templates/_helpers.tmpl
+++ b/workflow/charts/fluentd/templates/_helpers.tmpl
@@ -10,3 +10,12 @@ rbac.authorization.k8s.io/v1alpha1
 rbac.authorization.k8s.io/v1
 {{- end -}}
 {{- end -}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/workflow/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: DaemonSet
 metadata:
   name: deis-logger-fluentd

--- a/workflow/charts/logger/templates/_helpers.tmpl
+++ b/workflow/charts/logger/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/logger/templates/logger-deployment.yaml
+++ b/workflow/charts/logger/templates/logger-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-logger

--- a/workflow/charts/minio/templates/_helpers.tmpl
+++ b/workflow/charts/minio/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/minio/templates/minio-deployment.yaml
+++ b/workflow/charts/minio/templates/minio-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.storage "minio" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-minio

--- a/workflow/charts/monitor/charts/grafana/templates/_helpers.tmpl
+++ b/workflow/charts/monitor/charts/grafana/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/monitor/charts/grafana/templates/monitor-grafana-deployment.yaml
+++ b/workflow/charts/monitor/charts/grafana/templates/monitor-grafana-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.grafana_location "on-cluster" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-monitor-grafana

--- a/workflow/charts/monitor/charts/influxdb/templates/_helpers.tmpl
+++ b/workflow/charts/monitor/charts/influxdb/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/monitor/charts/influxdb/templates/monitor-influxdb-deployment.yaml
+++ b/workflow/charts/monitor/charts/influxdb/templates/monitor-influxdb-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.influxdb_location "on-cluster" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-monitor-influxdb

--- a/workflow/charts/monitor/charts/telegraf/templates/_helpers.tmpl
+++ b/workflow/charts/monitor/charts/telegraf/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/monitor/charts/telegraf/templates/monitor-telegraf-daemon.yaml
+++ b/workflow/charts/monitor/charts/telegraf/templates/monitor-telegraf-daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: DaemonSet
 metadata:
   name: deis-monitor-telegraf

--- a/workflow/charts/nsqd/templates/_helpers.tmpl
+++ b/workflow/charts/nsqd/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/nsqd/templates/nsqd-deployment.yaml
+++ b/workflow/charts/nsqd/templates/nsqd-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-nsqd

--- a/workflow/charts/redis/templates/_helpers.tmpl
+++ b/workflow/charts/redis/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/redis/templates/logger-redis-deployment.yaml
+++ b/workflow/charts/redis/templates/logger-redis-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.logger_redis_location "on-cluster" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-logger-redis

--- a/workflow/charts/registry-proxy/templates/_helpers.tmpl
+++ b/workflow/charts/registry-proxy/templates/_helpers.tmpl
@@ -1,0 +1,12 @@
+{{/*
+Set apiVersion based on .Capabilities.APIVersions
+*/}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/registry-proxy/templates/registry-proxy-daemon.yaml
+++ b/workflow/charts/registry-proxy/templates/registry-proxy-daemon.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.registry_location "on-cluster" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: DaemonSet
 metadata:
   name: deis-registry-proxy

--- a/workflow/charts/registry-token-refresher/templates/_helpers.tmpl
+++ b/workflow/charts/registry-token-refresher/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/registry-token-refresher/templates/registry-token-refresher-deployment.yaml
+++ b/workflow/charts/registry-token-refresher/templates/registry-token-refresher-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and (ne .Values.global.registry_location "on-cluster") (ne .Values.global.registry_location "off-cluster") }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-registry-token-refresher

--- a/workflow/charts/registry/templates/_helpers.tmpl
+++ b/workflow/charts/registry/templates/_helpers.tmpl
@@ -1,0 +1,9 @@
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/registry/templates/registry-deployment.yaml
+++ b/workflow/charts/registry/templates/registry-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.global.registry_location "on-cluster" }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-registry

--- a/workflow/charts/router/templates/_helpers.tmpl
+++ b/workflow/charts/router/templates/_helpers.tmpl
@@ -10,3 +10,12 @@ rbac.authorization.k8s.io/v1alpha1
 rbac.authorization.k8s.io/v1
 {{- end -}}
 {{- end -}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/router/templates/router-deployment.yaml
+++ b/workflow/charts/router/templates/router-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.global.experimental_native_ingress }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-router

--- a/workflow/charts/workflow-manager/templates/_helpers.tmpl
+++ b/workflow/charts/workflow-manager/templates/_helpers.tmpl
@@ -10,3 +10,12 @@ rbac.authorization.k8s.io/v1alpha1
 rbac.authorization.k8s.io/v1
 {{- end -}}
 {{- end -}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/workflow/charts/workflow-manager/templates/workflow-manager-deployment.yaml
+++ b/workflow/charts/workflow-manager/templates/workflow-manager-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-workflow-manager


### PR DESCRIPTION
Test upgrading chart (without yet any image upgrades, except for controller which is at teamhephy/controller#111)

The first thing I expect to fail, if this deploys at all, is builder. Maybe second is router! This is not feature complete, for review and testing only.

I was able to deploy the controller at teamhephy/controller#111 on a Kubernetes 1.15.x cluster (DigitalOcean DOK8s) with an upgraded manifest to apps/v1. It succeeded, and everything worked as expected. The goal with this precision operation here is to make it so that Kubernetes versions <1.12 which are lacking apps/v1 are not broken by chart upgrades enforcing apps/v1.

The machinery is all built to handle transitioning from one API version to the next, wherever APIs were alpha and moved into beta, thanks to Deis team's long history of intensive support. We should consider with this merge that we may need to do this again, and apps/v1 might not ever be the last iteration of Kubernetes deployment artifact that Workflow can handle running its workloads atop of. It may look like I've gone to some (perhaps unnecessary) trouble to support multiple API versions, (and that's because I have! But I don't believe it will turn out to have been unnecessary in the long-term.)