### PR TITLE
Use experimental native ingress, and define builder service as NodePort

### DIFF
--- a/releases/hephy-workflow.yaml
+++ b/releases/hephy-workflow.yaml
@@ -23,6 +23,9 @@ spec:
       database_location: on-cluster
       use_rbac: true
       use_cni: true
+      experimental_native_ingress: true
+    controller:
+      platform_domain: team.hephy.rocks
     router:
       host_port:
         enabled: false

--- a/workflow/charts/builder/templates/builder-service.yaml
+++ b/workflow/charts/builder/templates/builder-service.yaml
@@ -12,5 +12,5 @@ spec:
   selector:
     app: deis-builder
 {{ if .Values.global.experimental_native_ingress }}
-  type: "LoadBalancer"
+  type: "NodePort"
 {{ end }}


### PR DESCRIPTION
This was tested on DOK8s 1.16 and it worked! (No router support yet)