### PR TITLE
nginx-ingress in Helm Operator releases/ dir

### DIFF
--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-ingress
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress
+  namespace: nginx-ingress
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  releaseName: ingress
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    name: nginx-ingress
+    version: 1.40.2
+  values:
+    controller:
+      hostNetwork: true
+      daemonSet:
+        useHostPort: true
+      kind: DaemonSet
+      service:
+        type: NodePort


### PR DESCRIPTION
Configure using DaemonSet and HostPort networking (so there is no Load Balancer provisioned, this is for testing use only)